### PR TITLE
Remove unsupported TOC tag from post layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,12 +40,6 @@ layout: default
   </header>
 
   <article class="post-content">
-    {% if page.toc and page.toc.beginning %}
-    <div id="table-of-contents">
-      {% toc %}
-    </div>
-    <hr>
-    {% endif %}
     <div id="markdown-content">
       {{ content }}
     </div>


### PR DESCRIPTION
## Summary
- remove unsupported `{% toc %}` block from post template to avoid build errors on GitHub Pages

## Testing
- `pre-commit run --files _layouts/post.html` *(fails: command not found; `pip install pre-commit` could not access package repository)*

------
https://chatgpt.com/codex/tasks/task_e_689ce281dc60833398fe063bee33b466